### PR TITLE
Upgraded to version v0.7.1-beta

### DIFF
--- a/Formula/spacetime.rb
+++ b/Formula/spacetime.rb
@@ -3,14 +3,14 @@ class Spacetime < Formula
   desc "A command line interface for SpacetimeDB"
   homepage "https://spacetimedb.com"
 
-  version "0.7.0"
+  version "0.7.1"
 
   if Hardware::CPU.arm?
-    url "https://github.com/clockworklabs/SpacetimeDB/releases/download/v0.7.0-beta/spacetime.darwin-arm64.tar.gz"
-    sha256 "2e4d37bb4cfc8a7b5d2e1046a6cebde9718a7cd784138f4710b5e285dd8c11d8"
+    url "https://github.com/clockworklabs/SpacetimeDB/releases/download/v0.7.1-beta/spacetime.darwin-arm64.tar.gz"
+    sha256 "df67f355be45ec256e4a627a0fbc9df1487c3df8d3fa49d3ca0ad1d6889ec7bf"
   else
-    url "https://github.com/clockworklabs/SpacetimeDB/releases/download/v0.7.0-beta/spacetime.darwin-amd64.tar.gz"
-    sha256 "8d6f4346ed6d2aeca750952b7437174b92c55d1d06ca00b2c36d11e6586515ec"
+    url "https://github.com/clockworklabs/SpacetimeDB/releases/download/v0.7.1-beta/spacetime.darwin-amd64.tar.gz"
+    sha256 "92a726a36a371a95d8a008c220b3cec92f8f8ab14b5b599bcb4fa9f912c73947"
   end
 
 


### PR DESCRIPTION
 - Upgrades to CLI version `v0.7.1-beta`

## Testing

To test this:

```
> brew update
> brew upgrade spacetime
> spacetime version
Path: /Users/boppy/Downloads/build/spacetime
Commit: 37479049891098bb482d2f664a93e078fef0ad37
spacetimedb tool version 0.7.1; spacetimedb-lib version 0.7.1;
```
