### PR TITLE
SHA Updates After Fixing Sparse Issue

### DIFF
--- a/Formula/spacetime.rb
+++ b/Formula/spacetime.rb
@@ -7,10 +7,10 @@ class Spacetime < Formula
 
   if Hardware::CPU.arm?
     url "https://github.com/clockworklabs/SpacetimeDB/releases/download/v0.7.3-beta-hotfix1/spacetime.darwin-arm64.tar.gz"
-    sha256 "963222cdac49b357cc627ce4ec0edb5ac2eaa9ddc34ed4b2498e1d4d144aa86c"
+    sha256 "081b80d6dbe3f4f75df3d4f6d37ee5de152ce29b0d9eb5843057e49ae75cf9db"
   else
     url "https://github.com/clockworklabs/SpacetimeDB/releases/download/v0.7.3-beta-hotfix1/spacetime.darwin-amd64.tar.gz"
-    sha256 "ee051fc2fd947907d5244db155328afd7cb40407537d82e0a193b21e14ecf53b"
+    sha256 "4619d22c629d8466b881a7fa0e050818e5ffe6b81401a52e49c6882398a229ef" 
   end
 
 


### PR DESCRIPTION
 - There was an issue which prevented `spacetime upgrade` from working which required changing the tar files. These SHA changes reflect that.
