### PR TITLE
v0.9.2-beta

### DIFF
--- a/Formula/spacetime.rb
+++ b/Formula/spacetime.rb
@@ -6,11 +6,11 @@ class Spacetime < Formula
   version "0.8.2"
 
   if Hardware::CPU.arm?
-    url "https://github.com/clockworklabs/SpacetimeDB/releases/download/v0.9.1-beta/spacetime.darwin-arm64.tar.gz"
-    sha256 "05f7cdc649d8a872d1279c451edc7d9268d7cd0a72d72ffd691c0b776f3a09dc"
+    url "https://github.com/clockworklabs/SpacetimeDB/releases/download/v0.9.2-beta/spacetime.darwin-arm64.tar.gz"
+    sha256 "d4e4d58181d4de65652f4a48adc4220d97ea27b5be15eef21fb7423069c91917"
   else
-    url "https://github.com/clockworklabs/SpacetimeDB/releases/download/v0.9.1-beta/spacetime.darwin-amd64.tar.gz"
-    sha256 "5a99f52fc87831ac99da8ad5afe2a0250477ad31b33efce491797294e19fb644"
+    url "https://github.com/clockworklabs/SpacetimeDB/releases/download/v0.9.2-beta/spacetime.darwin-amd64.tar.gz"
+    sha256 "2251be77451ec845241cd95f35e9b86e0b2805673127d0468c86fc027842b610"
   end
 
 


### PR DESCRIPTION
This Pull Request bumps the version number and updates the sha256 digests for v0.9.2-beta.

```bash
~/Downloads ❯ sha256sum spacetime.darwin-arm64.tar.gz
d4e4d58181d4de65652f4a48adc4220d97ea27b5be15eef21fb7423069c91917  spacetime.darwin-arm64.tar.gz

~/Downloads ❯ sha256sum spacetime.darwin-amd64.tar.gz
2251be77451ec845241cd95f35e9b86e0b2805673127d0468c86fc027842b610  spacetime.darwin-amd64.tar.gz
```