### PR TITLE
Update tap to `v1.0.0-rc3`

### DIFF
--- a/Formula/spacetime.rb
+++ b/Formula/spacetime.rb
@@ -3,14 +3,14 @@ class Spacetime < Formula
   desc "A command line interface for SpacetimeDB"
   homepage "https://spacetimedb.com"
 
-  version "1.0.0-rc2"
+  version "1.0.0-rc3"
 
   if Hardware::CPU.arm?
-    url "https://github.com/clockworklabs/SpacetimeDB/releases/download/v1.0.0-rc2-hotfix2/spacetime.darwin-arm64.tar.gz"
-    sha256 "4cddd78a92a98cdd4f2870779f271f8204424d8b788f76248d4dc626d5e5b86a"
+    url "https://github.com/clockworklabs/SpacetimeDB/releases/download/v1.0.0-rc3/spacetime.darwin-arm64.tar.gz"
+    sha256 "b5d311931a39b60cb86282d7983d9ea7596ed461baa9713e53d0826f8200f763"
   else
-    url "https://github.com/clockworklabs/SpacetimeDB/releases/download/v1.0.0-rc2-hotfix2/spacetime.darwin-amd64.tar.gz"
-    sha256 "56bf7f3d381663dc674b2b45d0fc3309c63e7f038b97f1f36c09430a28cc8c9b"
+    url "https://github.com/clockworklabs/SpacetimeDB/releases/download/v1.0.0-rc3/spacetime.darwin-amd64.tar.gz"
+    sha256 "da7045dc4243aa786512c424452ea796e36d0146d398ce6d68237247ab3e96eb"
   end
 
 

--- a/Formula/spacetime.rb
+++ b/Formula/spacetime.rb
@@ -6,11 +6,11 @@ class Spacetime < Formula
   version "1.0.0-rc3"
 
   if Hardware::CPU.arm?
-    url "https://github.com/clockworklabs/SpacetimeDB/releases/download/v1.0.0-rc3/spacetime.darwin-arm64.tar.gz"
-    sha256 "b5d311931a39b60cb86282d7983d9ea7596ed461baa9713e53d0826f8200f763"
+    url "https://github.com/clockworklabs/SpacetimeDB/releases/download/v1.0.0-rc3-hotfix1/spacetime.darwin-arm64.tar.gz"
+    sha256 "230740fee768fcc62aa0882d705b107a8715ebcbb7c3c125310919c8e7e2169f"
   else
-    url "https://github.com/clockworklabs/SpacetimeDB/releases/download/v1.0.0-rc3/spacetime.darwin-amd64.tar.gz"
-    sha256 "da7045dc4243aa786512c424452ea796e36d0146d398ce6d68237247ab3e96eb"
+    url "https://github.com/clockworklabs/SpacetimeDB/releases/download/v1.0.0-rc3-hotfix1/spacetime.darwin-amd64.tar.gz"
+    sha256 "3a64e7e72620a9af4d50db95d2d37f6c00bb64e0c55332b610e613c6d39b44bc"
   end
 
 


### PR DESCRIPTION
Updated tap to `v1.0.0-rc3`, which corresponds to the SpacetimeDB tag `v1.0.0-rc3-hotfix1`.